### PR TITLE
add : clientの新規登録機能実装

### DIFF
--- a/client/client.xcodeproj/project.pbxproj
+++ b/client/client.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"client/Preview Content\"";
-				DEVELOPMENT_TEAM = LBAQD48WFX;
+				DEVELOPMENT_TEAM = XVZ2LPCAL2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "このアプリはカメラを使用します";
@@ -457,7 +457,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.myu.HelloWorld;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kazuyoshiogata;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -473,7 +473,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"client/Preview Content\"";
-				DEVELOPMENT_TEAM = LBAQD48WFX;
+				DEVELOPMENT_TEAM = XVZ2LPCAL2;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "このアプリはカメラを使用します";
@@ -486,7 +486,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.myu.HelloWorld;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kazuyoshiogata;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/client/client/TOP/Register/RegisterEntryView.swift
+++ b/client/client/TOP/Register/RegisterEntryView.swift
@@ -9,7 +9,9 @@ import SwiftUI
 
 struct RegisterEntryView: View {
     var body: some View {
-        Text("新規登録確認前")
+        NavigationLink(destination: RegisterMainView()){
+            Text("新規登録する")
+        }
     }
 }
 

--- a/client/client/TOP/Register/RegisterMainView.swift
+++ b/client/client/TOP/Register/RegisterMainView.swift
@@ -8,9 +8,51 @@
 import SwiftUI
 
 struct RegisterMainView: View {
-    var body: some View {
-        Text("新規登録画面")
-    }
+    @State private var username = ""
+    @State private var password = ""
+    @State private var confirmPassword = ""
+    @State private var isSingUp = false
+    @State private var showingAlert=false
+    @State private var confirmPassAlert = false
+    @State private var showingAlerMsg = ""
+
+       var body: some View {
+           TextField("ユーザー名",text: $username).autocapitalization(/*@START_MENU_TOKEN@*/.none/*@END_MENU_TOKEN@*/)
+           SecureField("パスワード",text: $password).autocapitalization(/*@START_MENU_TOKEN@*/.none/*@END_MENU_TOKEN@*/)
+           SecureField("確認用パスワード",text: $confirmPassword).autocapitalization(/*@START_MENU_TOKEN@*/.none/*@END_MENU_TOKEN@*/)
+
+           Button(action: {() in
+               Task {
+                   if password == confirmPassword {
+                       let sendData = ["username":self.username,
+                                       "password":self.password]
+                       print("sendData : \(sendData)")
+                       let result = await apiSignUpPostRequest(reqBody: sendData)
+                       print("result : \(result.message)")
+                       if result.message == "新規登録完了" {
+                           isSingUp = true
+                       } else {
+                           showingAlert = true
+                           showingAlerMsg = "すでに存在しているユーザー名です"
+                           
+                       }
+                   } else {
+                       showingAlert = true
+                       showingAlerMsg = "パスワードと確認用パスワードが一致しません"
+                   }
+                   
+               }
+               
+           }){
+               Text("新規登録")
+           }
+           NavigationLink(destination:HomeView(), isActive: $isSingUp) {
+                       EmptyView()
+           }.alert(isPresented: $showingAlert) {
+               
+               Alert(title: Text("エラー"), message: Text(showingAlerMsg), dismissButton: .default(Text("OK")))
+           }
+           }
 }
 
 //#Preview {

--- a/client/client/api/Auth.swift
+++ b/client/client/api/Auth.swift
@@ -38,22 +38,31 @@ func apiAuthPostRequest(reqBody : [String: String]) async -> ResponseMessage {
     return message!
 }
 
-//func apiImageGetRequest() async throws -> [ApiImage] {
-//    try await withCheckedContinuation { continuation in
-//        AF.request(apiEndPoint, method: .get)
-//            .response{ response in
-//                let decoder = JSONDecoder()
-//                do {
-//                    let images = try decoder.decode([ApiImage].self, from: response.data!)
-//                    continuation.resume(returning: images)
-//                    print("GET images type : \(type(of:images))")
-//                } catch {
-//                    print("Error decoding JSON: \(error)")
-//                    continuation.resume(throwing: error as! Never)
-//                }
-//            }
-//    }
-//}
+//新規登録用postメソッド
+func apiSignUpPostRequest(reqBody : [String: String]) async -> ResponseMessage {
+    var message: ResponseMessage?
+    do {
+        await withCheckedContinuation { continuation in
+            AF.request("\(apiAuthEndPoint)/signup", method: .post, parameters: reqBody)
+                .response{ response in
+                    print("response : \(response)")
+                    let decoder = JSONDecoder()
+                    do {
+                       message = try decoder.decode(ResponseMessage.self, from: response.data!)
+                        continuation.resume(returning: message!)
+                    } catch {
+                        message = ResponseMessage(message: "UnAuthorize")
+                        continuation.resume(returning: message!)
+                    }
+                }
+        }
+    } catch {
+        print("Error connecting to the server: \(error)")
+        // ここで元のページに戻るロジックを実装します。
+        // 具体的な実装は、あなたのアプリのナビゲーションの設定によります。
+    }
+    return message!
+}
 
 
 


### PR DESCRIPTION
clientの新規登録機能実装完了しました。
これ以降は本ファイルをバックチームは触りませんので、UIの作成お願いします。


実装機能：
1. 新規登録すると、データベースにユーザーが登録される＆自動でログイン後画面にリダイレクト
2. 同じユーザー名を登録しようとすると、エラーで登録できない
3. パスワードと確認用パスワードが一致しないとユーザー登録できない

NavigationLinkの警告の直し方わからなかったので、修正してもらえるとありがたいです。
よろしくお願いします。